### PR TITLE
Run from Anywhere, allow empty arguments, use any JIRA project

### DIFF
--- a/config.json.skel
+++ b/config.json.skel
@@ -3,7 +3,7 @@
     "url": "JIRAWEBLINKBASE"
   },
   "git": {
-    "base_dir": "YOURLOCALREPO",
+    "base_dir": "OPTIONALBASEDIRTODEFAULTTO",
     "prod_tag_prefix": "YOURPRODTAGPREFIX"
   },
   "github": {

--- a/config.json.skel
+++ b/config.json.skel
@@ -1,7 +1,6 @@
 {
   "jira": {
-    "project": "YOURGITHUBREPONAME",
-    "url": "YOURJIRAWEBLINK"
+    "url": "JIRAWEBLINKBASE"
   },
   "git": {
     "base_dir": "YOURLOCALREPO",

--- a/merged-prs
+++ b/merged-prs
@@ -35,7 +35,7 @@ $message = '';
 /**
  * Accept arguments as the Git hashes to use to determine merged branches
  */
-if ($argv[1] && $argv[2]) {
+if (!empty($argv[1]) && !empty($argv[2])) {
     $output = [
         $argv[1],
         $argv[2],

--- a/merged-prs
+++ b/merged-prs
@@ -65,8 +65,14 @@ if (!empty($argv[1]) && !empty($argv[2])) {
      */
     exec('git -C ' . $baseDir . ' tags | grep ' . $config['git']['prod_tag_prefix'] . ' | tail -r -2', $output);
 }
+if (empty($output[0]) || empty($output[1])) {
+    error_log("No hashes found, exiting.");
+    exit;
+}
+
 exec('git -C ' . $baseDir . ' log --merges --grep="Merge pull request" --pretty=format:"%s" ' . "{$output[0]}...{$output[1]}", $result);
-echo "Determining merged branches between the following hashes: {$output[0]} {$output[1]}" . PHP_EOL . PHP_EOL;
+echo "Executing for: {$baseDir}" . PHP_EOL;
+echo "Determining merged PRs between the following hashes: {$output[0]} {$output[1]}" . PHP_EOL . PHP_EOL;
 
 /**
  * Iterate through Shell Output and create array of the matching GitHub Issues IDs

--- a/merged-prs
+++ b/merged-prs
@@ -104,7 +104,7 @@ foreach ($issueList as $issueId) {
 
     // Check for JIRA Link
     $matches = [];
-    preg_match('/(' . $config['jira']['project'] . '\-[0-9]+)/', $result['body'], $matches);
+    preg_match('/([A-Za-z]+\-[0-9]+)/', $result['body'], $matches);
     if (count($matches) > 0) {
         $jiraUrl = $config['jira']['url'] . $matches[0];
     }

--- a/merged-prs
+++ b/merged-prs
@@ -6,7 +6,7 @@
  */
 
 // Require Configuration
-$config = json_decode(file_get_contents('config.json'), true);
+$config = json_decode(file_get_contents(__DIR__ . '/config.json'), true);
 if (!$config) {
     throw new Exception('config.json file missing!');
 }
@@ -33,6 +33,23 @@ if (isset($options['test']) && $options['test'] === false) {
 $message = '';
 
 /**
+ * Determine BaseDir (use config, or local)
+ */
+$currentDir = getcwd();
+$gitStatus = 0;
+$gitResult = [];
+exec("git -C {$currentDir} rev-parse > /dev/null 2>&1", $gitResult, $gitStatus);
+
+if ($gitStatus === 0) {
+    $baseDir = $currentDir;
+} elseif (isset($config['git']['base_dir'])) {
+    $baseDir = $config['git']['base_dir'];
+} else {
+    error_log("Current directory is not a GIT directory and no git.base_dir is set in config, exiting.");
+    exit;
+}
+
+/**
  * Accept arguments as the Git hashes to use to determine merged branches
  */
 if (!empty($argv[1]) && !empty($argv[2])) {
@@ -46,9 +63,9 @@ if (!empty($argv[1]) && !empty($argv[2])) {
      * Determine previous two tags beginning with 'prod-' and get the list of branches
      * merged (into master) between them. Then pull out the GitHub Issue IDs
      */
-    exec('cd ' . $config['git']['base_dir'] . ' && git tags | grep ' . $config['git']['prod_tag_prefix'] . ' | tail -r -2', $output);
+    exec('git -C ' . $baseDir . ' tags | grep ' . $config['git']['prod_tag_prefix'] . ' | tail -r -2', $output);
 }
-exec('cd ' . $config['git']['base_dir'] . ' && git log --merges --grep="Merge pull request" --pretty=format:"%s" ' . "{$output[0]}...{$output[1]}", $result);
+exec('git -C ' . $baseDir . ' log --merges --grep="Merge pull request" --pretty=format:"%s" ' . "{$output[0]}...{$output[1]}", $result);
 echo "Determining merged branches between the following hashes: {$output[0]} {$output[1]}" . PHP_EOL . PHP_EOL;
 
 /**


### PR DESCRIPTION
Rolled up improvements to the merged-prs tool
#### Allow the file to be run from anywhere.
- This is helpful to allow use outside of a single project.
- If this script is in your $PATH you can run inside of any repo.
#### Allow any JIRA project
- Allows any JIRA project string to be pulled from a PR description and parsed.
#### Allow empty Arguments
- No longer receive a warning for empty arguments passed to the script.
- Useful to find the merged PRs between the last two production tags.

@bigthyme 
